### PR TITLE
feat: add shadcn-svelte setup

### DIFF
--- a/frontend/components.json
+++ b/frontend/components.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://tw3.shadcn-svelte.com/schema.json",
+        "style": "default",
+        "tailwind": {
+                "config": "tailwind.config.cjs",
+		"css": "src/app.css",
+		"baseColor": "slate"
+	},
+	"aliases": {
+		"components": "$lib/components",
+		"utils": "$lib/utils",
+		"ui": "$lib/components/ui",
+		"hooks": "$lib/hooks"
+	},
+	"typescript": true,
+	"registry": "https://tw3.shadcn-svelte.com/registry"
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,14 @@
 		"svelte": "^5.0.0",
 		"svelte-check": "^4.0.0",
 		"tailwindcss": "^3.4.17",
+		"tailwindcss-animate": "^1.0.7",
 		"typescript": "^5.0.0",
 		"vite": "^7.0.4"
+	},
+	"dependencies": {
+		"clsx": "^2.1.1",
+		"radix-svelte": "^0.9.0",
+		"shadcn-svelte": "^1.0.7",
+		"tailwind-merge": "^3.3.1"
 	}
 }

--- a/frontend/src/lib/components/ui/button.svelte
+++ b/frontend/src/lib/components/ui/button.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { cn } from "$lib/utils";
+  import type { HTMLButtonAttributes } from "svelte/elements";
+
+  type Variant = "default" | "destructive" | "outline" | "secondary" | "ghost" | "link";
+  type Size = "default" | "sm" | "lg" | "icon";
+
+  export let variant: Variant = "default";
+  export let size: Size = "default";
+  export let className = "";
+  export let disabled: HTMLButtonAttributes["disabled"];
+
+  const variants: Record<Variant, string> = {
+    default: "bg-primary text-primary-foreground hover:bg-primary/90",
+    destructive: "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+    outline: "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+    secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+    ghost: "hover:bg-accent hover:text-accent-foreground",
+    link: "text-primary underline-offset-4 hover:underline"
+  };
+
+  const sizes: Record<Size, string> = {
+    default: "h-10 px-4 py-2",
+    sm: "h-9 rounded-md px-3",
+    lg: "h-11 rounded-md px-8",
+    icon: "h-10 w-10"
+  };
+</script>
+
+<button
+  class={cn(
+    "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+    variants[variant],
+    sizes[size],
+    className
+  )}
+  {disabled}
+  {...$$restProps}
+>
+  <slot />
+</button>

--- a/frontend/src/lib/components/ui/index.ts
+++ b/frontend/src/lib/components/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as Button } from "./button.svelte";

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/frontend/tailwind.config.cjs
+++ b/frontend/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: ['class'],
   content: ['./src/**/*.{html,js,svelte,ts}'],
   theme: {
     extend: {
@@ -19,5 +20,5 @@ module.exports = {
       },
     },
   },
-  plugins: [],
+  plugins: [require('tailwindcss-animate')],
 };


### PR DESCRIPTION
## Summary
- install shadcn-svelte, radix-svelte and utility deps
- scaffold initial shadcn-svelte configuration and button component
- enable tailwindcss-animate plugin

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a608d6a6f083298853339dd392dc5b