### PR TITLE
feat: add example component using lucide icons

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
 	},
 	"dependencies": {
 		"clsx": "^2.1.1",
+		"lucide-svelte": "^0.540.0",
 		"radix-svelte": "^0.9.0",
 		"shadcn-svelte": "^1.0.7",
 		"tailwind-merge": "^3.3.1"

--- a/frontend/src/lib/components/Example.svelte
+++ b/frontend/src/lib/components/Example.svelte
@@ -1,0 +1,5 @@
+<script>
+  import { Plus } from "lucide-svelte";
+</script>
+
+<Plus size="24" />


### PR DESCRIPTION
## Summary
- install lucide-svelte icon library
- add Example component demonstrating Plus icon

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68a60ba6da948329bb9c63c701ed8298