### PR TITLE
Add Supabase authentication scaffolding

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,3 @@
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key
+VITE_SUPABASE_REDIRECT_URL=http://localhost:5173/confirm

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
 		"vite": "^7.0.4"
 	},
 	"dependencies": {
+		"@supabase/supabase-js": "^2.55.0",
 		"clsx": "^2.1.1",
 		"lucide-svelte": "^0.540.0",
 		"radix-svelte": "^0.9.0",

--- a/frontend/src/lib/components/OAuthButtons.svelte
+++ b/frontend/src/lib/components/OAuthButtons.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { supabase } from '$lib/supabaseClient';
+
+  const signInWithProvider = async (provider: 'github' | 'google') => {
+    await supabase.auth.signInWithOAuth({ provider, options: { redirectTo: import.meta.env.VITE_SUPABASE_REDIRECT_URL } });
+  };
+</script>
+
+<button on:click={() => signInWithProvider('github')}>Sign in with GitHub</button>
+<button on:click={() => signInWithProvider('google')}>Sign in with Google</button>

--- a/frontend/src/lib/sessionStore.ts
+++ b/frontend/src/lib/sessionStore.ts
@@ -1,0 +1,13 @@
+import { writable } from 'svelte/store';
+import type { Session } from '@supabase/supabase-js';
+import { supabase } from './supabaseClient';
+
+export const session = writable<Session | null>(null);
+
+supabase.auth.getSession().then(({ data }) => {
+  session.set(data.session);
+});
+
+supabase.auth.onAuthStateChange((_event, newSession) => {
+  session.set(newSession);
+});

--- a/frontend/src/lib/supabaseClient.ts
+++ b/frontend/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL as string;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/frontend/src/routes/confirm/+page.svelte
+++ b/frontend/src/routes/confirm/+page.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import { supabase } from '$lib/supabaseClient';
+  import { page } from '$app/stores';
+  let message = 'Confirming...';
+
+  onMount(async () => {
+    const code = $page.url.searchParams.get('code');
+    if (code) {
+      const { error } = await supabase.auth.exchangeCodeForSession(code);
+      message = error ? error.message : 'Email confirmed! You can close this window.';
+    } else {
+      message = 'No confirmation code found.';
+    }
+  });
+</script>
+
+<p>{message}</p>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { supabase } from '$lib/supabaseClient';
+  import OAuthButtons from '$lib/components/OAuthButtons.svelte';
+  let email = '';
+  let message = '';
+
+  const sendMagicLink = async () => {
+    const { error } = await supabase.auth.signInWithOtp({
+      email,
+      options: { emailRedirectTo: import.meta.env.VITE_SUPABASE_REDIRECT_URL }
+    });
+    message = error ? error.message : 'Check your email for a magic link to log in.';
+  };
+</script>
+
+<form on:submit|preventDefault={sendMagicLink}>
+  <input type="email" bind:value={email} placeholder="Email" required />
+  <button type="submit">Send Magic Link</button>
+</form>
+
+<OAuthButtons />
+
+{#if message}<p>{message}</p>{/if}

--- a/frontend/src/routes/signup/+page.svelte
+++ b/frontend/src/routes/signup/+page.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import { supabase } from '$lib/supabaseClient';
+  let email = '';
+  let password = '';
+  let message = '';
+
+  const signUp = async () => {
+    const { error } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { emailRedirectTo: import.meta.env.VITE_SUPABASE_REDIRECT_URL }
+    });
+    message = error ? error.message : 'Check your email to confirm your account.';
+  };
+</script>
+
+<form on:submit|preventDefault={signUp}>
+  <input type="email" bind:value={email} placeholder="Email" required />
+  <input type="password" bind:value={password} placeholder="Password" required />
+  <button type="submit">Sign Up</button>
+</form>
+
+{#if message}<p>{message}</p>{/if}


### PR DESCRIPTION
## Summary
- install @supabase/supabase-js
- add supabase client and session store
- add auth routes for sign-up, magic link login, OAuth, and email confirmation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a616a2403c8329bd4ba872f271fb96